### PR TITLE
run via pytest-benchmark

### DIFF
--- a/.github/workflows/np_codspeed.yml
+++ b/.github/workflows/np_codspeed.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
            # XXX openblas wheel is super old for x86_64
-           pip install -i https://pypi.anaconda.org/multibuild-wheels-staging/simple scipy-openblas32 
+           # pip install -i https://pypi.anaconda.org/multibuild-wheels-staging/simple scipy-openblas32 
+           pip install scipy-openblas32
            pip install pytest pytest-codspeed threadpoolctl cython ninja meson pkgconfig spin
 
       - name: Clone and build numpy

--- a/.github/workflows/np_codspeed.yml
+++ b/.github/workflows/np_codspeed.yml
@@ -11,12 +11,16 @@ on:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        pyver: ["3.12"]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.12"
+          python-version: {{matrix.pyver}}
 
       - name: Install dependencies
         run: |
@@ -39,7 +43,7 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
             ls -l $PWD/numpy/build-install
-            export PYTHONPATH=$PWD/numpy/build-install/usr/lib/python3.12/site-packages/
+            export PYTHONPATH=$PWD/numpy/build-install/usr/lib/python{{matrix.pyver}}/site-packages/
             OPENBLAS_NUM_THREADS=1 pytest bench_np.py --codspeed
             # XXX how to check that numpy uses openblas not lapack-lite?
 

--- a/.github/workflows/np_codspeed.yml
+++ b/.github/workflows/np_codspeed.yml
@@ -27,7 +27,7 @@ jobs:
            # XXX openblas wheel is super old for x86_64
            # pip install -i https://pypi.anaconda.org/multibuild-wheels-staging/simple scipy-openblas32 
            pip install scipy-openblas32
-           pip install pytest pytest-codspeed threadpoolctl cython ninja meson pkgconfig spin
+           pip install pytest pytest-benchmark threadpoolctl cython ninja meson pkgconfig spin
 
       - name: Clone and build numpy
         run: |
@@ -45,6 +45,6 @@ jobs:
           run: |
             ls -l $PWD/numpy/build-install
             export PYTHONPATH=$PWD/numpy/build-install/usr/lib/python${{matrix.pyver}}/site-packages/
-            OPENBLAS_NUM_THREADS=1 pytest bench_np.py --codspeed
+            OPENBLAS_NUM_THREADS=1 pytest bench_np.py
             # XXX how to check that numpy uses openblas not lapack-lite?
 

--- a/.github/workflows/np_codspeed.yml
+++ b/.github/workflows/np_codspeed.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: {{matrix.pyver}}
+          python-version: ${{matrix.pyver}}
 
       - name: Install dependencies
         run: |
@@ -43,7 +43,7 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
             ls -l $PWD/numpy/build-install
-            export PYTHONPATH=$PWD/numpy/build-install/usr/lib/python{{matrix.pyver}}/site-packages/
+            export PYTHONPATH=$PWD/numpy/build-install/usr/lib/python${{matrix.pyver}}/site-packages/
             OPENBLAS_NUM_THREADS=1 pytest bench_np.py --codspeed
             # XXX how to check that numpy uses openblas not lapack-lite?
 


### PR DESCRIPTION
codspeed is limited to ubuntu runners, let's see if we can use macos runners with plain pytest-bench